### PR TITLE
ci: save docker build tag in gh secrets

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -50,3 +50,15 @@ jobs:
         with:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME}}/${{ steps.set-repo.outputs.REPO_NAME }}:${{ steps.commit-hash.outputs.COMMIT_HASH }}
+      
+      - name: Save Latest Build Tag as a GitHub Org Secret
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          REPO_NAME=${GITHUB_REPOSITORY##*/}
+          BUILD=${{ secrets.DOCKERHUB_USERNAME}}/${{ steps.set-repo.outputs.REPO_NAME }}:${{ steps.commit-hash.outputs.COMMIT_HASH }}
+
+          echo "[INFO] Setting the GitHub Org secret to the latest Helm Chart package: $BUILD"
+          gh secret set PLANT_COACH_WEATHER_API_DOCKER_BUILD --org Plant-Coach --visibility all --body "$BUILD"
+          
+          echo "[INFO] Done!"


### PR DESCRIPTION
Automate saving the latest docker build tag as a gh secret